### PR TITLE
Immediately closing files after read/write

### DIFF
--- a/osuElements.sln
+++ b/osuElements.sln
@@ -111,20 +111,23 @@ Global
 		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|ARM.Build.0 = Debug|Any CPU
-		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|x64.ActiveCfg = Debug|x64
-		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|x64.Build.0 = Debug|x64
-		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|x86.ActiveCfg = Debug|x86
-		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|x86.Build.0 = Debug|x86
+		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|x64.Build.0 = Debug|Any CPU
+		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Debug|x86.Build.0 = Debug|Any CPU
 		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|ARM.ActiveCfg = Release|Any CPU
 		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|ARM.Build.0 = Release|Any CPU
-		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|x64.ActiveCfg = Release|x64
-		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|x64.Build.0 = Release|x64
-		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|x86.ActiveCfg = Release|x86
-		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|x86.Build.0 = Release|x86
+		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|x64.ActiveCfg = Release|Any CPU
+		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|x64.Build.0 = Release|Any CPU
+		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|x86.ActiveCfg = Release|Any CPU
+		{CF4DD0E3-874E-4CEC-BC40-1AC0A6A1FB66}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {50E43FA4-B6D9-40F1-A2E3-526CCC74592B}
 	EndGlobalSection
 EndGlobal

--- a/osuElements/Api/ApiError.cs
+++ b/osuElements/Api/ApiError.cs
@@ -15,5 +15,10 @@ namespace osuElements.Api
         [DataMember(Name = "error", Order = 0)]
         public string Error { get; set; }
 
+        public override string ToString()
+        {
+            return Error;
+        }
+
     }
 }

--- a/osuElements/Beatmaps/Beatmap.cs
+++ b/osuElements/Beatmaps/Beatmap.cs
@@ -89,12 +89,16 @@ namespace osuElements.Beatmaps
             }
         }
         public void ReadFile(ILogger logger = null) {
-            osuElements.BeatmapFileRepository.ReadFile(osuElements.StreamIOStrategy.ReadStream(FullPath), this, logger);
+            using (var stream = osuElements.StreamIOStrategy.ReadStream(FullPath)) {
+                osuElements.BeatmapFileRepository.ReadFile(stream, this, logger);
+            }
             if (FormatVersion < 8) DifficultyApproachRate = DifficultyHpDrainRate;
             IsRead = true;
         }
         public void WriteFile() {
-            osuElements.BeatmapFileRepository.WriteFile(osuElements.StreamIOStrategy.WriteStream(FullPath), this);
+            using (var stream = osuElements.StreamIOStrategy.WriteStream(FullPath)) {
+                osuElements.BeatmapFileRepository.WriteFile(stream, this);
+            }
         }
         #endregion
 
@@ -127,8 +131,9 @@ namespace osuElements.Beatmaps
         public string GetHash(bool forceRenew = false) {
             if (!forceRenew && !string.IsNullOrWhiteSpace(BeatmapHash)) return BeatmapHash;
             var md5 = MD5.Create();
-            BeatmapHash = md5.ComputeHash(osuElements.StreamIOStrategy.ReadStream(FullPath)).
-                Aggregate("", (current, b) => current + b.ToString("x2"));
+            using (var stream = osuElements.StreamIOStrategy.ReadStream(FullPath)) {
+                BeatmapHash = md5.ComputeHash(stream).Aggregate("", (current, b) => current + b.ToString("x2"));
+            }
             return BeatmapHash;
         }
 

--- a/osuElements/Db/CollectionDb.cs
+++ b/osuElements/Db/CollectionDb.cs
@@ -64,12 +64,16 @@ namespace osuElements.Db
             }
         }
         public void ReadFile(ILogger logger = null) {
-            osuElements.CollectionDbRepository.ReadFile(osuElements.StreamIOStrategy.ReadStream(FullPath), this, logger);
+            using (var stream = osuElements.StreamIOStrategy.ReadStream(FullPath)) {
+                osuElements.CollectionDbRepository.ReadFile(stream, this, logger);
+            }
             IsRead = true;
         }
 
         public void WriteFile() {
-            osuElements.CollectionDbRepository.WriteFile(osuElements.StreamIOStrategy.WriteStream(FullPath), this);
+            using (var stream = osuElements.StreamIOStrategy.WriteStream(FullPath)) {
+                osuElements.CollectionDbRepository.WriteFile(stream, this);
+            }
         }
         #endregion
 

--- a/osuElements/Db/OsuDb.cs
+++ b/osuElements/Db/OsuDb.cs
@@ -38,12 +38,16 @@ namespace osuElements.Db
             }
         }
         public void ReadFile(ILogger logger = null) {
-            osuElements.OsuDbRepository.ReadFile(osuElements.StreamIOStrategy.ReadStream(FullPath), this, logger);
+            using (var stream = osuElements.StreamIOStrategy.ReadStream(FullPath)) {
+                osuElements.OsuDbRepository.ReadFile(stream, this, logger);
+            }
             IsRead = true;
         }
 
         public void WriteFile() {
-            osuElements.OsuDbRepository.WriteFile(osuElements.StreamIOStrategy.WriteStream(FullPath), this);
+            using (var stream = osuElements.StreamIOStrategy.WriteStream(FullPath)) {
+                osuElements.OsuDbRepository.WriteFile(stream, this);
+            }
         }
         public static BinaryFile<OsuDb> FileReader() {
             var result = new BinaryFile<OsuDb>(

--- a/osuElements/Db/ScoresDb.cs
+++ b/osuElements/Db/ScoresDb.cs
@@ -47,12 +47,16 @@ namespace osuElements.Db
             }
         }
         public void ReadFile(ILogger logger = null) {
-            osuElements.ScoresDbRepository.ReadFile(osuElements.StreamIOStrategy.ReadStream(FullPath), this, logger);
+            using (var stream = osuElements.StreamIOStrategy.ReadStream(FullPath)) {
+                osuElements.ScoresDbRepository.ReadFile(stream, this, logger);
+            }
             IsRead = true;
         }
 
         public void WriteFile() {
-            osuElements.ScoresDbRepository.WriteFile(osuElements.StreamIOStrategy.WriteStream(FullPath), this);
+            using (var stream = osuElements.StreamIOStrategy.WriteStream(FullPath)) {
+                osuElements.ScoresDbRepository.WriteFile(stream, this);
+            }
         }
         #endregion
     }

--- a/osuElements/Replays/Replay.cs
+++ b/osuElements/Replays/Replay.cs
@@ -66,11 +66,15 @@ namespace osuElements.Replays
             }
         }
         public void ReadFile(ILogger logger = null) {
-            osuElements.ReplayFileRepository.ReadFile(osuElements.StreamIOStrategy.ReadStream(FullPath), this, logger);
+            using (var stream = osuElements.StreamIOStrategy.ReadStream(FullPath)) {
+                osuElements.ReplayFileRepository.ReadFile(stream, this, logger);
+            }
             IsRead = true;
         }
         public void WriteFile() {
-            osuElements.ReplayFileRepository.WriteFile(osuElements.StreamIOStrategy.WriteStream(FullPath), this);
+            using (var stream = osuElements.StreamIOStrategy.WriteStream(FullPath)) {
+                osuElements.ReplayFileRepository.WriteFile(stream, this);
+            }
         }
         #endregion
 

--- a/osuElements/Skins/Skin.cs
+++ b/osuElements/Skins/Skin.cs
@@ -38,11 +38,15 @@ namespace osuElements.Skins
             }
         }
         public void ReadFile(ILogger logger = null) {
-            osuElements.SkinFileRepository.ReadFile(osuElements.StreamIOStrategy.ReadStream(FullPath), this, logger);
+            using (var stream = osuElements.StreamIOStrategy.ReadStream(FullPath)) {
+                osuElements.SkinFileRepository.ReadFile(stream, this, logger);
+            }
             IsRead = true;
         }
         public void WriteFile() {
-            osuElements.SkinFileRepository.WriteFile(osuElements.StreamIOStrategy.WriteStream(FullPath), this);
+            using (var stream = osuElements.StreamIOStrategy.WriteStream(FullPath)) {
+                osuElements.SkinFileRepository.WriteFile(stream, this);
+            }
         }
         #endregion
 

--- a/osuElements/Storyboards/Storyboard.cs
+++ b/osuElements/Storyboards/Storyboard.cs
@@ -65,11 +65,15 @@ namespace osuElements.Storyboards
             }
         }
         public void ReadFile(ILogger logger = null) {
-            osuElements.StoryboardFileRepository.ReadFile(osuElements.StreamIOStrategy.ReadStream(FullPath), this, logger);
+            using (var stream = osuElements.StreamIOStrategy.ReadStream(FullPath)) {
+                osuElements.StoryboardFileRepository.ReadFile(stream, this, logger);
+            }
             IsRead = true;
         }
         public void WriteFile() {
-            osuElements.StoryboardFileRepository.WriteFile(osuElements.StreamIOStrategy.WriteStream(FullPath), this);
+            using (var stream = osuElements.StreamIOStrategy.WriteStream(FullPath)) {
+                osuElements.StoryboardFileRepository.WriteFile(stream, this);
+            }
         }
         public static FileReader<Storyboard> FileReader() {
             return new FileReader<Storyboard>(


### PR DESCRIPTION
For example if i read Beatmap and after reading move this file to another directory then exception will be thrown because FileStream is not disposed at the moment and file is locked by this stream. So i think FileStreams should be disposed right after all IO is finished, in current code nothing will be broken by this patch.