### PR TITLE
DB reader update, API throttling

### DIFF
--- a/osuElements/Api/Repositories/ApiMultiplayerRepository.cs
+++ b/osuElements/Api/Repositories/ApiMultiplayerRepository.cs
@@ -1,10 +1,18 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using osuElements.Api.Throttling;
 
 namespace osuElements.Api.Repositories
 {
     public class ApiMultiplayerRepository : ApiRepositoryBase, IApiMultiplayerRepository
     {
+
+        public ApiMultiplayerRepository() : base() { }
+
+        public ApiMultiplayerRepository(string apiKey, bool throwExceptions, IThrottler throttler) : base(apiKey, throwExceptions, throttler) { }
+
+
+
         public async Task<ApiMatchResult> Get(int matchId) {
             var result = (await GetList<ApiMatchResult>($"get_match?id={matchId}"))?.FirstOrDefault();
             if (result == null) return null;

--- a/osuElements/Api/Repositories/ApiReplayRepository.cs
+++ b/osuElements/Api/Repositories/ApiReplayRepository.cs
@@ -2,11 +2,19 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using osuElements.Api.Throttling;
 
 namespace osuElements.Api.Repositories
 {
     public class ApiReplayRepository: ApiRepositoryBase, IApiReplayRepository
     {
+
+        public ApiReplayRepository() : base() { }
+
+        public ApiReplayRepository(string apiKey, bool throwExceptions, IThrottler throttler) : base(apiKey, throwExceptions, throttler) { }
+
+
+
         public async Task<ApiReplay> Get(int mapId, int userId, GameMode mode) {
             return await GetData<ApiReplay>($"get_replay?b={mapId}&u={userId}&m={(int) mode}");
         }

--- a/osuElements/Api/Repositories/ApiScoreRepository.cs
+++ b/osuElements/Api/Repositories/ApiScoreRepository.cs
@@ -1,15 +1,23 @@
-﻿using osuElements.Helpers;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using static osuElements.Helpers.Constants;
+using osuElements.Api.Throttling;
+using osuElements.Helpers;
 
 namespace osuElements.Api.Repositories
 {
     public class ApiScoreRepository : ApiRepositoryBase, IApiScoreRepository
     {
+
+        public ApiScoreRepository() : base() { }
+
+        public ApiScoreRepository(string apiKey, bool throwExceptions, IThrottler throttler) : base(apiKey, throwExceptions, throttler) { }
+
+
+
         public async Task<List<ApiScore>> GetMapScores(int mapId, int userid, GameMode mode = GameMode.Standard, Mods? mods = null, int limit = MaxApiScoreResults)
         {
             var modstring = mods.HasValue ? $"&mods={(int)mods.Value}" : "";

--- a/osuElements/Api/Repositories/ApiUserRepository.cs
+++ b/osuElements/Api/Repositories/ApiUserRepository.cs
@@ -3,25 +3,20 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using osuElements.Api.Throttling;
 using osuElements.Helpers;
-using static osuElements.GameMode;
 using static osuElements.Helpers.Constants;
 
 namespace osuElements.Api.Repositories
 {
     public class ApiUserRepository : ApiRepositoryBase, IApiUserRepository
     {
-        Lazy<IApiScoreRepository> _apiScoreRepository;
 
-        public ApiUserRepository()
-        {
-            _apiScoreRepository = new Lazy<IApiScoreRepository>(() => new ApiScoreRepository(), true);
-        }
+        public ApiUserRepository() : base() { }
 
-        public ApiUserRepository(IApiScoreRepository apiScoreRepository)
-        {
-            _apiScoreRepository = new Lazy<IApiScoreRepository>(() => apiScoreRepository, true);
-        }
+        public ApiUserRepository(string apiKey, bool throwExceptions, IThrottler throttler) : base(apiKey, throwExceptions, throttler) { }
+
+
 
         public async Task<ApiUser> Get(string name, GameMode mode = 0, int eventDays = MaxApiEventDays)
         {
@@ -47,30 +42,5 @@ namespace osuElements.Api.Repositories
             return result;
         }
 
-        // Methods below left for backward compatibility
-
-        public async Task<List<ApiScore>> GetBest(int id, GameMode mode = Standard, int limit = MaxApiScoreResults)
-        {
-            return await CallNestedRepository(_apiScoreRepository.Value, async (repo) => await
-                repo.GetUserBest(id, mode, limit));
-        }
-
-        public async Task<List<ApiScore>> GetBest(string name, GameMode mode = Standard, int limit = MaxApiScoreResults)
-        {
-            return await CallNestedRepository(_apiScoreRepository.Value, async (repo) => await
-                repo.GetUserBest(name, mode, limit));
-        }
-
-        public async Task<List<ApiScore>> GetRecent(int id, GameMode mode = Standard, int limit = MaxApiScoreResults)
-        {
-            return await CallNestedRepository(_apiScoreRepository.Value, async (repo) => await
-                repo.GetUserBest(id, mode, limit));
-        }
-
-        public async Task<List<ApiScore>> GetRecent(string name, GameMode mode = Standard, int limit = MaxApiScoreResults)
-        {
-            return await CallNestedRepository(_apiScoreRepository.Value, async (repo) => await
-                repo.GetUserBest(name, mode, limit));
-        }
     }
 }

--- a/osuElements/Api/Repositories/IApiRepository.cs
+++ b/osuElements/Api/Repositories/IApiRepository.cs
@@ -38,37 +38,6 @@ namespace osuElements.Api.Repositories
         /// <param name="mode">the gamemode for the data</param>
         /// <param name="eventDays">max amount of days for the event data, between 1 and 31</param>
         Task<ApiUser> Get(int id, GameMode mode = Standard, int eventDays = MaxApiEventDays);
-
-        /// <summary>
-        /// Returns the top scores for the specified user.
-        /// </summary>
-        /// <param name="name">username, cannot be ID</param>
-        /// <param name="mode">the gamemode for the data</param>
-        /// <param name="limit">max amount of results, between 1 and 100</param>
-        Task<List<ApiScore>> GetBest(string name, GameMode mode = Standard, int limit = MaxApiScoreResults);
-        /// <summary>
-        /// Returns the top scores for the specified user.
-        /// </summary>
-        /// <param name="id">user ID, cannot be name</param>
-        /// <param name="mode">the gamemode for the data</param>
-        /// <param name="limit">max amount of results, between 1 and 100</param>
-        Task<List<ApiScore>> GetBest(int id, GameMode mode = Standard, int limit = MaxApiScoreResults);
-
-        /// <summary>
-        /// Returns most recent scores for the specified user.
-        /// </summary>
-        /// <param name="name">username, cannot be ID</param>
-        /// <param name="mode">the gamemode for the data</param>
-        /// <param name="limit">max amount of results, between 1 and 100</param>
-        Task<List<ApiScore>> GetRecent(string name, GameMode mode = Standard, int limit = MaxApiScoreResults);
-
-        /// <summary>
-        /// Returns most recent scores for the specified user.
-        /// </summary>
-        /// <param name="id">user ID, cannot be name</param>
-        /// <param name="mode">the gamemode for the data</param>
-        /// <param name="limit">max amount of results, between 1 and 100</param>
-        Task<List<ApiScore>> GetRecent(int id, GameMode mode = Standard, int limit = MaxApiScoreResults);
     }
 
     public interface IApiBeatmapRepository : IApiRepository
@@ -113,16 +82,6 @@ namespace osuElements.Api.Repositories
         /// <param name="mapHash">the beatmap hash</param>
         /// <param name="mode">optional, only gamemode to return results from</param>
         Task<ApiBeatmap> Get(string mapHash, GameMode? mode = null);
-        /// <summary>
-        /// Returns the top scores for the specified beatmap.
-        /// </summary>
-        /// <param name="mapId">beatmap ID</param>
-        /// <param name="userid">optional, specify a user's ID to get a score for</param>
-        /// <param name="username">optional, specify a user's username to get a score for</param>
-        /// <param name="mode">optional, specify a gamemode to get scores for</param>
-        /// <param name="mods">optional, specify mods to get scores for</param>
-        /// <param name="limit">max amount of results, between 1 and 100</param>
-        Task<List<ApiScore>> GetScores(int mapId, int? userid = null, string username = null, GameMode mode = Standard, Mods? mods = null, int limit = MaxApiScoreResults);
     }
 
     public interface IApiReplayRepository : IApiRepository
@@ -154,16 +113,56 @@ namespace osuElements.Api.Repositories
 
     public interface IApiScoreRepository : IApiRepository
     {
+        /// <summary>
+        /// Returns the top scores for the specified user.
+        /// </summary>
+        /// <param name="id">user ID, cannot be name</param>
+        /// <param name="mode">the gamemode for the data</param>
+        /// <param name="limit">max amount of results, between 1 and 100</param>
         Task<List<ApiScore>> GetUserBest(int userId, GameMode mode = Standard, int limit = MaxApiScoreResults);
 
+        /// <summary>
+        /// Returns the top scores for the specified user.
+        /// </summary>
+        /// <param name="userName">username, cannot be ID</param>
+        /// <param name="mode">the gamemode for the data</param>
+        /// <param name="limit">max amount of results, between 1 and 100</param>
         Task<List<ApiScore>> GetUserBest(string userName, GameMode mode = Standard, int limit = MaxApiScoreResults);
 
+        /// <summary>
+        /// Returns most recent scores for the specified user.
+        /// </summary>
+        /// <param name="userId">user ID, cannot be name</param>
+        /// <param name="mode">the gamemode for the data</param>
+        /// <param name="limit">max amount of results, between 1 and 100</param>
         Task<List<ApiScore>> GetUserRecent(int userId, GameMode mode = Standard, int limit = MaxApiScoreResults);
 
+        /// <summary>
+        /// Returns most recent scores for the specified user.
+        /// </summary>
+        /// <param name="userName">username, cannot be ID</param>
+        /// <param name="mode">the gamemode for the data</param>
+        /// <param name="limit">max amount of results, between 1 and 100</param>
         Task<List<ApiScore>> GetUserRecent(string userName, GameMode mode = Standard, int limit = MaxApiScoreResults);
 
-        Task<List<ApiScore>> GetMapScores(int mapId, string username = null, GameMode mode = Standard, Mods? mods = null, int limit = MaxApiScoreResults);
+        /// <summary>
+        /// Returns the top scores for the specified beatmap.
+        /// </summary>
+        /// <param name="mapId">beatmap ID</param>
+        /// <param name="userName">optional, specify a user's username to get a score for</param>
+        /// <param name="mode">optional, specify a gamemode to get scores for</param>
+        /// <param name="mods">optional, specify mods to get scores for</param>
+        /// <param name="limit">max amount of results, between 1 and 100</param>
+        Task<List<ApiScore>> GetMapScores(int mapId, string userName = null, GameMode mode = Standard, Mods? mods = null, int limit = MaxApiScoreResults);
 
-        Task<List<ApiScore>> GetMapScores(int mapId, int userid, GameMode mode = Standard, Mods? mods = null, int limit = MaxApiScoreResults);
+        /// <summary>
+        /// Returns the top scores for the specified beatmap.
+        /// </summary>
+        /// <param name="mapId">beatmap ID</param>
+        /// <param name="userId">optional, specify a user's ID to get a score for</param>
+        /// <param name="mode">optional, specify a gamemode to get scores for</param>
+        /// <param name="mods">optional, specify mods to get scores for</param>
+        /// <param name="limit">max amount of results, between 1 and 100</param>
+        Task<List<ApiScore>> GetMapScores(int mapId, int userId, GameMode mode = Standard, Mods? mods = null, int limit = MaxApiScoreResults);
     }
 }

--- a/osuElements/Api/Throttling/IThrottler.cs
+++ b/osuElements/Api/Throttling/IThrottler.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace osuElements.Api.Throttling
+{
+    public interface IThrottler: IDisposable
+    {
+        Task WaitAsync();
+    }
+}

--- a/osuElements/Api/Throttling/NoThrottler.cs
+++ b/osuElements/Api/Throttling/NoThrottler.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace osuElements.Api.Throttling
+{
+    public class NoThrottler: IThrottler
+    {
+        private bool _disposedValue;
+
+        public Task WaitAsync() => Task.CompletedTask;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/osuElements/Api/Throttling/NoThrottler.cs
+++ b/osuElements/Api/Throttling/NoThrottler.cs
@@ -11,7 +11,7 @@ namespace osuElements.Api.Throttling
     {
         private bool _disposedValue;
 
-        public Task WaitAsync() => Task.CompletedTask;
+        public Task WaitAsync() => Task.FromResult(true);
 
         protected virtual void Dispose(bool disposing)
         {

--- a/osuElements/Api/Throttling/TimerThrottler.cs
+++ b/osuElements/Api/Throttling/TimerThrottler.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace osuElements.Api.Throttling
+{
+    public class TimerThrottler: IThrottler
+    {
+
+        readonly SemaphoreSlim _waitSemaphore = new SemaphoreSlim(1, 1);
+
+        readonly Timer _resetTimer;
+        readonly TimeSpan _cooldown;
+        private bool _disposedValue;
+
+        public TimerThrottler(TimeSpan cooldown)
+        {
+            _cooldown = cooldown;
+            _resetTimer = new Timer(_ => _waitSemaphore.Release(), null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+
+        public TimerThrottler(int actions, TimeSpan perTime)
+            : this(TimeSpan.FromMilliseconds(perTime.TotalMilliseconds / actions))
+        {
+
+        }
+
+
+
+        public async Task WaitAsync()
+        {
+            await _waitSemaphore.WaitAsync();
+            if (!_resetTimer.Change(_cooldown, Timeout.InfiniteTimeSpan))
+                throw new Exception("Timer update error");
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _resetTimer.Dispose();
+                    _waitSemaphore.Dispose();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/osuElements/Db/DbBeatmap.cs
+++ b/osuElements/Db/DbBeatmap.cs
@@ -7,14 +7,15 @@ namespace osuElements.Db
 {
     public enum DbBeatmapState
     {
-        None,
-        Unsubmitted,
-        Graveyard,
-        WorkInProgress,
-        Ranked,
-        Approved,
-        Qualified,
+        None = 0,
+        Unsubmitted = 1,
+        Pending = 2, WorkInProgress = 2, Graveyard = 2,
+        Ranked = 4,
+        Approved = 5,
+        Qualified = 6,
+        Loved = 7
     }
+
     /// <summary>
     /// The database-driven approach to the beatmap object
     /// </summary>
@@ -53,10 +54,7 @@ namespace osuElements.Db
         public bool Unplayed { get; set; }
         public bool Osz2 { get; set; } 
         public byte ManiaScrollSpeed { get; set; }
-        public int ByteLength { get; set; } //the length in bytes of this data in the database
-
-        //Unsure
-        public int Int { get; set; } //nearly always 0
-        public bool Bool2 { get; set; } //nearly always false
+        public int LastModificationTime { get; set; }
+        public bool VisualOverride { get; set; }
     }
 }

--- a/osuElements/Db/OsuDb.cs
+++ b/osuElements/Db/OsuDb.cs
@@ -10,6 +10,19 @@ using osuElements.IO.File;
 
 namespace osuElements.Db
 {
+
+    [Flags]
+    public enum OsuUserPersissions
+    { 
+        None = 0, 
+        Normal = 1, 
+        Moderator = 2, 
+        Supporter = 4, 
+        Friend = 8, 
+        Peppy = 16, 
+        WorldCupStaff = 32
+    }
+
     public class OsuDb
     {
         public OsuDb() {
@@ -19,9 +32,8 @@ namespace osuElements.Db
         public int CollectionCount { get; set; }
         public string UserName { get; set; }
         public List<DbBeatmap> Beatmaps { get; set; }
-        //unsure
-        public int SomeInt { get; set; }
-        public bool SomeBool { get; set; }
+        public OsuUserPersissions UserPermissions { get; set; }
+        public bool AccountUnlocked { get; set; }
         public DateTime DateTime { get; set; }
 
         #region File
@@ -53,11 +65,10 @@ namespace osuElements.Db
             var result = new BinaryFile<OsuDb>(
                 new BinaryFileLine<OsuDb, int>(s => s.FileVersion),
                 new BinaryFileLine<OsuDb, int>(s => s.CollectionCount),
-                new BinaryFileLine<OsuDb, bool>(s => s.SomeBool),
+                new BinaryFileLine<OsuDb, bool>(s => s.AccountUnlocked),
                 new BinaryFileLine<OsuDb, DateTime>(s => s.DateTime),
                 new BinaryFileLine<OsuDb, string>(s => s.UserName),
                 new BinaryCollection<OsuDb, DbBeatmap>(s => s.Beatmaps,
-                    new BinaryFileLine<DbBeatmap, int>(b => b.ByteLength),
                     new BinaryFileLine<DbBeatmap, string>(b => b.Artist),
                     new BinaryFileLine<DbBeatmap, string>(b => b.ArtistUnicode),
                     new BinaryFileLine<DbBeatmap, string>(b => b.Title),
@@ -77,9 +88,7 @@ namespace osuElements.Db
                     new BinaryFileLine<DbBeatmap, float>(b => b.DifficultyHpDrainRate),
                     new BinaryFileLine<DbBeatmap, float>(b => b.DifficultyOverall),
                     new BinaryFileLine<DbBeatmap, double>(b => b.DifficultySliderMultiplier),
-                    new BinaryFileDictionary<DbBeatmap, Mods, double>(b => b.StandardDifficulties) {
-                        KeyType = typeof(int)
-                    },
+                    new BinaryFileDictionary<DbBeatmap, Mods, double>(b => b.StandardDifficulties) { KeyType = typeof(int) },
                     new BinaryFileDictionary<DbBeatmap, Mods, double>(b => b.TaikoDifficulties) { KeyType = typeof(int) },
                     new BinaryFileDictionary<DbBeatmap, Mods, double>(b => b.CtbDifficulties) { KeyType = typeof(int) },
                     new BinaryFileDictionary<DbBeatmap, Mods, double>(b => b.ManiaDifficulties) { KeyType = typeof(int) },
@@ -113,12 +122,12 @@ namespace osuElements.Db
                     new BinaryFileLine<DbBeatmap, bool>(b => b.IgnoreSkin),
                     new BinaryFileLine<DbBeatmap, bool>(b => b.IgnoreStoryboard),
                     new BinaryFileLine<DbBeatmap, bool>(b => b.IgnoreVideo),
-                    new BinaryFileLine<DbBeatmap, bool>(b => b.Bool2),
-                    new BinaryFileLine<DbBeatmap, int>(b => b.Int),
+                    new BinaryFileLine<DbBeatmap, bool>(b => b.VisualOverride),
+                    new BinaryFileLine<DbBeatmap, int>(b => b.LastModificationTime),
                     new BinaryFileLine<DbBeatmap, byte>(b => b.ManiaScrollSpeed)
                     ),
 
-                new BinaryFileLine<OsuDb, int>(s => s.SomeInt)
+                new BinaryFileLine<OsuDb, OsuUserPersissions>(s => s.UserPermissions) { Type = typeof(int) }
                 );
             return result;
         }

--- a/osuElements/IO/Binary/BinaryFileLine.cs
+++ b/osuElements/IO/Binary/BinaryFileLine.cs
@@ -38,7 +38,13 @@ namespace osuElements.IO.Binary
             WriteObject(writer, value);
         }
 
-        protected void WriteObject(BinaryWriter writer, object t) {
+        protected void WriteObject(BinaryWriter writer, object obj) {
+            object t = obj;
+
+            if (obj is Enum && Enum.GetUnderlyingType(obj.GetType()) != Type) {
+                t = Convert.ChangeType(obj, Type);
+            }
+
             if (Type == typeof(string)) {
                 writer.WriteNullableString((string)t);
             }

--- a/osuElements/IO/Binary/BinaryFileList.cs
+++ b/osuElements/IO/Binary/BinaryFileList.cs
@@ -53,7 +53,7 @@ namespace osuElements.IO.Binary
         }
 
         public override void WriteValue(BinaryWriter writer, TClass instance) {
-            //NYI
+            throw new NotImplementedException("Binary dictionary writing is not implemented yet.");
         }
     }
 }

--- a/osuElements/Properties/AssemblyInfo.cs
+++ b/osuElements/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("osuElements")]
-[assembly: AssemblyCopyright("Copyright © 2016")]
+[assembly: AssemblyCopyright("Copyright © 2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.7.0")]
-[assembly: AssemblyFileVersion("1.0.7.0")]
+[assembly: AssemblyVersion("1.0.8.0")]
+[assembly: AssemblyFileVersion("1.0.8.0")]

--- a/osuElements/osuElements.NET.csproj
+++ b/osuElements/osuElements.NET.csproj
@@ -47,6 +47,9 @@
     <Compile Include="Api\ApiError.cs" />
     <Compile Include="Api\EventConverter.cs" />
     <Compile Include="Api\Repositories\ApiScoreRepository.cs" />
+    <Compile Include="Api\Throttling\IThrottler.cs" />
+    <Compile Include="Api\Throttling\NoThrottler.cs" />
+    <Compile Include="Api\Throttling\TimerThrottler.cs" />
     <Compile Include="Beatmaps\Difficulty\DifficultyCalculatorBase.cs" />
     <Compile Include="Beatmaps\Difficulty\CtbDifficultyCalculator.cs" />
     <Compile Include="Beatmaps\Difficulty\Enums.cs" />

--- a/osuElements/osuElements.Standard.csproj
+++ b/osuElements/osuElements.Standard.csproj
@@ -4,7 +4,14 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>osuElements.Standard</AssemblyName>
     <RootNamespace>osuElements</RootNamespace>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.0.8</Version>
+    <AssemblyVersion>1.0.8.0</AssemblyVersion>
+    <Copyright>osuElements 2021</Copyright>
+    <Description>an open source osu! framework</Description>
+    <Product>osuElements.Standard</Product>
+    <Company>osuElements.Standard</Company>
+    <Authors>osuElements.Standard</Authors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/osuElements/osuElements.cs
+++ b/osuElements/osuElements.cs
@@ -1,6 +1,8 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.Win32;
 using osuElements.Api.Repositories;
+using osuElements.Api.Throttling;
 using osuElements.Beatmaps;
 using osuElements.Db;
 using osuElements.IO;
@@ -24,11 +26,15 @@ namespace osuElements
             OsuDbRepository = OsuDb.FileReader();
             ScoresDbRepository = ScoresDb.FileReader();
 
-            ApiReplayRepository = new ApiReplayRepository();
+            // ApiRepositoryThrottler = new TimerThrottler(60, TimeSpan.FromMinutes(1));
+            ApiRepositoryThrottler = null;
+
+            ApiMultiplayerRepository = new ApiMultiplayerRepository();
             ApiBeatmapRepository = new ApiBeatmapRepository();
             ApiReplayRepository = new ApiReplayRepository();
             ApiUserRepository = new ApiUserRepository();
             ApiScoreRepository = new ApiScoreRepository();
+
 
             StreamIOStrategy = new StreamIOStrategy();
 
@@ -79,14 +85,9 @@ namespace osuElements
         public static IApiUserRepository ApiUserRepository { get; set; }
         public static IApiMultiplayerRepository ApiMultiplayerRepository { get; set; }
         public static IApiScoreRepository ApiScoreRepository { get; set; }
-        public static string ApiKey
-        {
-            set { ApiRepositoryBase.Key = value; }
-        }
-        public static bool ApiRepositoryThrowExceptions
-        {
-            set { ApiRepositoryBase.ThrowExceptions = value; }
-        }
+        public static string ApiKey { get; set; }
+        public static bool ApiRepositoryThrowExceptions { get; set; } = false;
+        public static IThrottler ApiRepositoryThrottler { get; set; }
         public static int LatestBeatmapVersion { get; set; } = 14;
         public static float LatestSkinVersion { get; set; } = 2.5f;
 


### PR DESCRIPTION
Hello!

The main goal of this PR is to fix *.db file reader, now it can read files with version `20191106` and later.

Unknown properties like `SomeBool`, `Byte`, `Byte2`, etc renamed, `DbBeatmapStatus` enum entries slightly changed, added enum for UserPersmissons, all this according to [osu wiki](https://osu.ppy.sh/wiki/en/osu%21_File_Formats/Db_%28file_format%29).

Regular Int32 Enums now can be saved as Bytes, unfornunately your commit mentioned [here](https://github.com/JasperDeSutter/osuElements/pull/9#issuecomment-282400447) did not fixed this.

`NotImplementedException` added because i tried read-write to `osu!.db` and this always results in file with less data than i just read, turns out `WriteValue` for binary dictionaries is just empty. Absense of exceptions or at least console message here was very confusing.

API repositories now can be throttled. In practice it seems to be not needed today, but i already implemented this. Maybe would be usefull in multithreading.
